### PR TITLE
Add null check to domIsDescendant

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -101,7 +101,7 @@ define(["./sniff", "./_base/window", "./_base/kernel"],
 	dom.isDescendant = has("dom-contains") ?
 		// FF9+, IE9+, webkit, opera, iOS, Android, Edge, etc.
 		function(/*DOMNode|String*/ node, /*DOMNode|String*/ ancestor){
-			return !!( (ancestor = dom.byId(ancestor)) && ancestor.contains(dom.byId(node)) );
+			return !!( (ancestor = dom.byId(ancestor)) && ancestor.contains && ancestor.contains(dom.byId(node)) );
 		} :
 		function(/*DOMNode|String*/ node, /*DOMNode|String*/ ancestor){
 			// summary:


### PR DESCRIPTION
In scenarios where the node is not found in the dom, instead of just failing when ancestor.contains() is called, check to make sure ancestor.contains exists.